### PR TITLE
Use a custom domain?

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+amber.rbind.io


### PR DESCRIPTION
I have pointed the CNAME record of amber.rbind.io to proquestionasker.github.io. If you accept this PR, the latter will be automatically redirected to the former.

I can change it to proquestionasker.rbind.io if you prefer.

Of course, feel free to close this (unsolicited) PR if you don't like the idea.